### PR TITLE
Add a buildkite dashboard 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "dotenv": "^6.0.0",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
     "react-scripts": "2.0.0-next.3e165448"

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import './App.css';
+import BuildkiteDashboard from './components/Buildkite';
 
 const Group = ({ heading, items }) => {
   return(
@@ -36,6 +37,7 @@ const App = ({ groups, compliment }) => {
       <h1 className="Main-greeting">
         {compliment}
       </h1>
+      <BuildkiteDashboard />
     </div>
   );
 };

--- a/src/components/Buildkite/index.js
+++ b/src/components/Buildkite/index.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const BuildkiteDashboard = () => {
+  const apiKey = process.env.REACT_APP_BUILDKITE_API_KEY;
+  
+  return (
+    <h3>
+      Alrighty? {apiKey}
+    </h3>
+  );
+};
+
+export default BuildkiteDashboard;

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,8 @@ import './index.css';
 import App from './App';
 import * as config from './config.json';
 
+require('dotenv').config();
+
 const generateCompliment = () => {
   const NAME = "Randeep";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3206,6 +3206,10 @@ dotenv@5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-5.0.1.tgz#a5317459bd3d79ab88cff6e44057a6a3fbb1fcef"
 
+dotenv@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.0.0.tgz#24e37c041741c5f4b25324958ebbc34bca965935"
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"


### PR DESCRIPTION
Add a buildkite dashboard to the new tab to easily check the build status of whatever builds you like.

**TODO:**

 - [x] Setup easily configurable environment variables
 - [ ]  Fetch data from the Buildkite GraphQL API
 - [ ]  Easily configurable list of repositories to fetch build info from
 - [ ] UI and Styling
 - [ ] Need to make sure it's performant (especially if you have a lot of new tabs open)